### PR TITLE
Add perlbrew install --as option

### DIFF
--- a/README.md
+++ b/README.md
@@ -304,6 +304,12 @@ The module name to pass to the `cpanm` utility.
 
 The set of flag(s), as a string, to pass to `cpanm`.
 
+##### `path`
+
+`Array` Defaults to `[/bin', '/usr/bin']`
+
+The set of path(s), as an Array, to pass to `Perlbrew::Cpanm[...]`.
+
 ##### `check_name`
 
 `String` Defaults to `undef`

--- a/README.md
+++ b/README.md
@@ -210,6 +210,13 @@ perlbrew::perl { 'perl-5.20.1':
   flags   => "--notest -j ${::processorcount}",
   timeout => 900,
 }
+
+perlbrew::perl { 'stable':
+  target  => '/home/moe', # required
+  as      => 'latest-stable',
+  flags   => "--notest -j ${::processorcount}",
+  timeout => 900,
+}
 ```
 
 ##### `target`
@@ -237,6 +244,8 @@ The version string of perl 5 release to be installed. Eg.
       perl5.004_05
       perl5.003_07
 
+In addition the following perlbrew generic tags such as 'perl-stable' or just 'stable'
+
 ##### `flags`
 
 `String` Defaults to `--notest -j ${::processorcount}`
@@ -244,6 +253,14 @@ The version string of perl 5 release to be installed. Eg.
 The option flag(s) passed to `perlbrew install` command. Note that the
 `--notest` flag dramatically speeds up the ammount of time require to install a
 perl version.
+
+##### `as`
+
+`String` Defaults to `undef`
+
+The option as enables the use of a perlbrew alias. It is required if the perl
+version is set to 'perl-stable' or 'stable'. 
+The option as passed to `perlbrew install` command.
 
 ##### `timeout`
 

--- a/manifests/cpanm.pp
+++ b/manifests/cpanm.pp
@@ -4,6 +4,7 @@ define perlbrew::cpanm (
   $target,
   $module     = $name,
   $flags      = '--notest',
+  $path       = ['/bin', '/usr/bin'],
   $check_name = undef,
   $timeout    = undef,
 ) {
@@ -11,6 +12,7 @@ define perlbrew::cpanm (
   validate_string($target)
   validate_string($module)
   validate_string($flags)
+  validate_array($path)
   validate_string($check_name)
   validate_string($timeout)
 
@@ -24,7 +26,7 @@ define perlbrew::cpanm (
   perlbrew::exec { $command:
     target    => $target,
     # needs path to git, chmod, make, etc.
-    path      => ['/bin', '/usr/bin'],
+    path      => $path,
     logoutput => true,
     timeout   => $timeout,
     unless    => "perl -M${testfor} -e '1'",

--- a/manifests/perl.pp
+++ b/manifests/perl.pp
@@ -49,7 +49,7 @@ define perlbrew::perl (
     $alias = $version
   }
 
-  exec { "${target}_install_${version}":
+  exec { "${target}_install_${alias}":
     command     => $command,
     path        => $perlbrew_path,
     environment => $perlbrew_env,
@@ -57,11 +57,11 @@ define perlbrew::perl (
     user        => $owner,
     group       => $group,
     logoutput   => true,
-    creates     => "${install_root}/perl5/perlbrew/perls/${version}",
+    creates     => "${install_root}/perl5/perlbrew/perls/${alias}",
     timeout     => $timeout,
-    unless      => "test ! -d ${install_root}/perl5/perlbrew/perls/${version}",
+    unless      => "test -d ${install_root}/perl5/perlbrew/perls/${alias}",
   } ->
-  exec { "${target}_install-cpanm-${version}":
+  exec { "${target}_install-cpanm-${alias}":
     command     => 'perlbrew install-cpanm',
     path        => $perlbrew_path,
     environment => $perlbrew_env,

--- a/manifests/perl.pp
+++ b/manifests/perl.pp
@@ -59,6 +59,7 @@ define perlbrew::perl (
     logoutput   => true,
     creates     => "${install_root}/perl5/perlbrew/perls/${version}",
     timeout     => $timeout,
+    unless      => "test ! -d ${install_root}/perl5/perlbrew/perls/${version}",
   } ->
   exec { "${target}_install-cpanm-${version}":
     command     => 'perlbrew install-cpanm',

--- a/manifests/perl.pp
+++ b/manifests/perl.pp
@@ -42,7 +42,7 @@ define perlbrew::perl (
 
   if $as {
     $alias = $as
-    $command = regsubst("perlbrew install --as $as ${flags} ${version}", '\s+', ' ', 'G')
+    $command = regsubst("perlbrew install --as ${as} ${flags} ${version}", '\s+', ' ', 'G')
   }
   else {
     $command = regsubst("perlbrew install ${flags} ${version}", '\s+', ' ', 'G')


### PR DESCRIPTION
Hi,
Thank you for your time and effort making and supporting the puppet-perlbrew module. It doesn't currently seem to support the --as option to perlbrew install, so i've patched the code and documentation. It seems to work in my test environment, Debian Jessie.

<snip debug log>
Debug: Exec[/opt_install_stable](provider=posix): Executing 'perlbrew install --as current --notest -j 1 stable'                                     │  
Debug: Executing 'perlbrew install --as current --notest -j 1 stable' 
Debug: Executing 'grep PERLBREW_PERL=\"current\" /opt/.perlbrew/init'                                                                                │  
Debug: /Stage[main]/Main/Perlbrew::Perl[stable]/Exec[/opt_switch_current]/unless: export PERLBREW_PERL="current"
<snip debug log>

Best Regards

Martin
