### PR TITLE
Integer value was getting validated as a string and failing

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,7 +247,7 @@ perl version.
 
 ##### `timeout`
 
-`String` Defaults to `900`
+`Integer` Defaults to `900`
 
 This sets the timeout on the `perlbrew install` command.  It may be nessicary
 to increase this value on a slow host or if the `--notest` flag is not being

--- a/manifests/perl.pp
+++ b/manifests/perl.pp
@@ -9,7 +9,7 @@ define perlbrew::perl (
   validate_string($target)
   validate_string($version)
   validate_string($flags)
-  validate_string($timeout)
+  validate_integer($timeout)
 
   Perlbrew[$target] -> Perlbrew::Perl[$name]
 


### PR DESCRIPTION
This was causing my rspec tests to fail. The default "timeout" variable is an integer so was failing on the "validate_string()" function.